### PR TITLE
Minor fixes to Generative AI class

### DIFF
--- a/GenAI/finetuning.ipynb
+++ b/GenAI/finetuning.ipynb
@@ -227,7 +227,8 @@
    "source": [
     "import ray\n",
     "import torch\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "from diffusers import DiffusionPipeline"
    ]
   },
   {
@@ -454,9 +455,7 @@
    "source": [
     "import itertools\n",
     "\n",
-    "from diffusers import (\n",
-    "    DiffusionPipeline,\n",
-    ")\n",
+    "from diffusers import DiffusionPipeline\n",
     "from ray import train\n",
     "from ray.train import ScalingConfig\n",
     "from ray.train.torch import TorchTrainer\n",

--- a/GenAI/serving.ipynb
+++ b/GenAI/serving.ipynb
@@ -347,7 +347,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "serve.run(entrypoint, port=port, name=\"dreambooth\", route_prefix=\"/\")\n",
+    "serve.run(entrypoint, port=port, name=\"dreambooth\")\n",
     "print(\"Done setting up replicas! Now accepting requests...\")"
    ]
   },


### PR DESCRIPTION
**Small Fixes**

Add in necessary import in finetuning.ipynb for augmenting the training dataset.
Remove reference to `route_prefix` in serving.ipynb.