### PR TITLE
GenAI - Fully utilize GPUs

### DIFF
--- a/GenAI/finetuning.ipynb
+++ b/GenAI/finetuning.ipynb
@@ -264,7 +264,7 @@
     "                np.array(image)\n",
     "            )  # This needs to be in the right format for writing.\n",
     "            print(f\"Generated image {i} of {self._num_samples}\")\n",
-    "        return [{\"image\": image} for image in images]\n"
+    "        return [{\"image\": image} for image in images]"
    ]
   },
   {
@@ -287,9 +287,9 @@
    "outputs": [],
    "source": [
     "class_name = \"dog\"  # General category of the subject matter.\n",
-    "prompts_list = [f\"photo of a {class_name}\"]\n",
+    "prompts_list = [f\"photo of a {class_name}\", f\"photo of a {class_name}\"]\n",
     "\n",
-    "num_samples_per_prompt = 200  # Number recommended in original paper."
+    "num_samples_per_prompt = 100  # Number recommended in original paper."
    ]
   },
   {
@@ -304,7 +304,7 @@
     "prompt_ds = ray.data.from_items(prompts_list)\n",
     "\n",
     "# Use `flat_map` to turn `n` prompts into `m` images.\n",
-    "images_ds = prompt_ds.flat_map(\n",
+    "images_ds = prompt_ds.repartition(2).flat_map(\n",
     "    StableDiffusionCallable,\n",
     "    compute=ray.data.ActorPoolStrategy(\n",
     "        size=2\n",


### PR DESCRIPTION
**Summary of changes**
Append the prompts_list with an identical prompt so that the Ray Dataset is now able to be repartitioned. Repartition the Dataset into two data blocks to fully utilize the two available GPUs. Maintain 200 total images as the target so size down num_samples_per_prompt to 100.